### PR TITLE
staging changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,13 @@ RUN apt-get-install.sh curl && curl -sL https://deb.nodesource.com/setup_12.x | 
     apt-get install nodejs -y && apt-get remove curl -y
 
 ARG CASEPRO_VERSION
-RUN echo "Downloading Casepro from https://github.com/rapidpro/casepro/archive/${CASEPRO_VERSION}.tar.gz"
-RUN apt-get update
-RUN apt-get-install.sh wget
-RUN wget -O casepro.tar.gz "https://github.com/rapidpro/casepro/archive/${CASEPRO_VERSION}.tar.gz"
-RUN tar -xf casepro.tar.gz --strip-components=1
-RUN rm casepro.tar.gz
-RUN apt-get remove wget -y
-RUN apt-get-install.sh build-essential
+RUN echo "Downloading Casepro from https://github.com/rapidpro/casepro/archive/${CASEPRO_VERSION}.tar.gz" && \
+    apt-get-install.sh wget && \
+    wget -O casepro.tar.gz "https://github.com/rapidpro/casepro/archive/${CASEPRO_VERSION}.tar.gz" && \
+    tar -xf casepro.tar.gz --strip-components=1 && \
+    rm casepro.tar.gz && \
+    apt-get remove wget -y && \
+    apt-get-install.sh build-essential 
 
 COPY nginx.conf /etc/nginx/conf.d/django.conf
 RUN nginx; service nginx reload
@@ -21,18 +20,16 @@ COPY settings.py casepro/settings.py
 
 RUN pip install --upgrade pip && pip install --upgrade poetry
 
-RUN poetry install --no-dev
-RUN poetry add django-environ
-
-RUN npm install -g less coffeescript
+# Poetry creates a virtual environment, this tells it not to, as it is in a docker container
+RUN poetry config virtualenvs.create false && \
+    poetry install --no-dev && \
+    poetry add django-environ && \
+    npm install -g less coffeescript
 
 ENV PROJECT_ROOT /casepro/
 ENV DJANGO_SETTINGS_MODULE "casepro.settings"
 RUN poetry run python ./manage.py collectstatic --noinput
-
+ENV USE_DEFAULT_CACHE=True
 RUN poetry run python ./manage.py compress
-
-# RUN django-admin collectstatic --noinput && \  
-    # USE_DEFAULT_CACHE=True django-admin compress
 
 CMD ["casepro.wsgi:application", "--timeout", "1800"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM praekeltfoundation/django-bootstrap:py3.6-stretch
 
-EXPOSE 6379
-
 RUN apt-get-install.sh curl && curl -sL https://deb.nodesource.com/setup_12.x | bash && \
     apt-get install nodejs -y && apt-get remove curl -y
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,14 @@ RUN apt-get-install.sh curl && curl -sL https://deb.nodesource.com/setup_12.x | 
     apt-get install nodejs -y && apt-get remove curl -y
 
 ARG CASEPRO_VERSION
-RUN echo "Downloading Casepro from https://github.com/rapidpro/casepro/archive/${CASEPRO_VERSION}.tar.gz" && \
-    apt-get-install.sh wget  && \
-    wget -O casepro.tar.gz "https://github.com/rapidpro/casepro/archive/${CASEPRO_VERSION}.tar.gz" && \
-    tar -xf casepro.tar.gz --strip-components=1 && \
-    rm casepro.tar.gz && \
-    apt-get remove wget -y
+RUN echo "Downloading Casepro from https://github.com/rapidpro/casepro/archive/${CASEPRO_VERSION}.tar.gz"
+RUN apt-get update
+RUN apt-get-install.sh wget
+RUN wget -O casepro.tar.gz "https://github.com/rapidpro/casepro/archive/${CASEPRO_VERSION}.tar.gz"
+RUN tar -xf casepro.tar.gz --strip-components=1
+RUN rm casepro.tar.gz
+RUN apt-get remove wget -y
+RUN apt-get-install.sh build-essential
 
 COPY nginx.conf /etc/nginx/conf.d/django.conf
 RUN nginx; service nginx reload
@@ -17,14 +19,20 @@ RUN nginx; service nginx reload
 COPY setup.py ./setup.py
 COPY settings.py casepro/settings.py
 
-RUN pip install -e . && \
-    pip install -r pip-freeze.txt && \
-    pip install django-environ && \
-    npm install -g less coffee-script
+RUN pip install --upgrade pip && pip install --upgrade poetry
+
+RUN poetry install --no-dev
+RUN poetry add django-environ
+
+RUN npm install -g less coffeescript
 
 ENV PROJECT_ROOT /casepro/
 ENV DJANGO_SETTINGS_MODULE "casepro.settings"
-RUN django-admin collectstatic --noinput && \  
-    USE_DEFAULT_CACHE=True django-admin compress
+RUN poetry run python ./manage.py collectstatic --noinput
+
+RUN poetry run python ./manage.py compress
+
+# RUN django-admin collectstatic --noinput && \  
+    # USE_DEFAULT_CACHE=True django-admin compress
 
 CMD ["casepro.wsgi:application", "--timeout", "1800"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,18 @@
 FROM praekeltfoundation/django-bootstrap:py3.6-stretch
 
+EXPOSE 6379
+
 RUN apt-get-install.sh curl && curl -sL https://deb.nodesource.com/setup_12.x | bash && \
     apt-get install nodejs -y && apt-get remove curl -y
 
 ARG CASEPRO_VERSION
-RUN echo "Downloading Casepro from https://github.com/rapidpro/casepro/archive/${CASEPRO_VERSION}.tar.gz"
-RUN apt-get update
-RUN apt-get-install.sh wget
-RUN wget -O casepro.tar.gz "https://github.com/rapidpro/casepro/archive/${CASEPRO_VERSION}.tar.gz"
-RUN tar -xf casepro.tar.gz --strip-components=1
-RUN rm casepro.tar.gz
-RUN apt-get remove wget -y
-RUN apt-get-install.sh build-essential
+RUN echo "Downloading Casepro from https://github.com/rapidpro/casepro/archive/${CASEPRO_VERSION}.tar.gz" && \
+    apt-get-install.sh wget && \
+    wget -O casepro.tar.gz "https://github.com/rapidpro/casepro/archive/${CASEPRO_VERSION}.tar.gz" && \
+    tar -xf casepro.tar.gz --strip-components=1 && \
+    rm casepro.tar.gz && \
+    apt-get remove wget -y && \
+    apt-get-install.sh build-essential 
 
 COPY nginx.conf /etc/nginx/conf.d/django.conf
 RUN nginx; service nginx reload
@@ -21,18 +22,16 @@ COPY settings.py casepro/settings.py
 
 RUN pip install --upgrade pip && pip install --upgrade poetry
 
-RUN poetry install --no-dev
-RUN poetry add django-environ
-
-RUN npm install -g less coffeescript
+# Poetry creates a virtual environment, this tells it not to, as it is in a docker container
+RUN poetry config virtualenvs.create false && \
+    poetry install --no-dev && \
+    poetry add django-environ && \
+    npm install -g less coffeescript
 
 ENV PROJECT_ROOT /casepro/
 ENV DJANGO_SETTINGS_MODULE "casepro.settings"
 RUN poetry run python ./manage.py collectstatic --noinput
-
+ENV USE_DEFAULT_CACHE=True
 RUN poetry run python ./manage.py compress
-
-# RUN django-admin collectstatic --noinput && \  
-    # USE_DEFAULT_CACHE=True django-admin compress
 
 CMD ["casepro.wsgi:application", "--timeout", "1800"]


### PR DESCRIPTION
Replacing PiP with Poetry
Changes: 

- `build-essential` installed because `gcc` is not in the Python slim docker image
- Stop Poetry from creating a virtual environment because docker is a virtual environment 
- Run python commands through Poetry