### PR TITLE
Issues updating dockerfile to latest casepro

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY setup.py ./setup.py
 COPY settings.py casepro/settings.py
 
 RUN pip install --upgrade pip && pip install --upgrade poetry
-
+ENV POETRY_VIRTUALENVS_PATH="venv"
 RUN poetry install --no-dev && \
     poetry add django-environ && \
     npm install -g less coffeescript
@@ -29,5 +29,6 @@ ENV DJANGO_SETTINGS_MODULE "casepro.settings"
 
 RUN poetry run python ./manage.py collectstatic --noinput
 RUN USE_DEFAULT_CACHE=True poetry run python ./manage.py compress
+RUN . $(poetry env info --path)/bin/activate
 
 CMD ["casepro.wsgi:application", "--timeout", "1800"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ RUN poetry run python ./manage.py collectstatic --noinput
 RUN USE_DEFAULT_CACHE=True poetry run python ./manage.py compress
 RUN . $(poetry env info --path)/bin/activate
 
-CMD ["casepro.wsgi:application", "--timeout", "1800"]
+ENTRYPOINT [ "poetry shell && django-entrypoint.sh" ]


### PR DESCRIPTION
I updated the casepro-docker dockerfile to use a later version of casepro, which makes use of Poetry instead of PiP, but I am having some trouble getting it to work 

for the previous update I did, we stopped Poetry from creating a virtual environment, but with a later version of casepro and python I ran into some conflicts, so we have to make use of the poetry virtual environment. The problem now is that the CMD line doesn't seem to want to run in the virtual environment. 

I have tried activating the virtual environment just before the CMD line, and then running the CMD as normal, but that returns a 
`error: exec: "django-admin": executable file not found in $PATH`
error, which indicates to me that its possibly not running in the virtual environement, 

So I tried using poetry run in the CMD but that returns a 
`[Errno 2] No such file or directory: b'/scripts/casepro.wsgi:application'`
error 

SO then I looked into activating the virtual environment and running the CMD in an entrypoint bash script but that returns 
`  [Errno 2] No such file or directory: b'/scripts/casepro.wsgi:application'`
So I also tried adding a `poetry build` line in the dockerfile thinking that maybe casepro isnt installing, but to no avail. 