### PR TITLE
Handle new csrf setting

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -19,6 +19,7 @@ SEND_EMAILS = True
 
 HOSTNAME = env.str('HOSTNAME', default='localhost:8000')
 SITE_HOST_PATTERN = env.str('SITE_HOST_PATTERN', default='http://%s.localhost:8000')
+CSRF_TRUSTED_ORIGINS = SITE_HOST_PATTERN % ("*")
 
 SITE_API_HOST = env.str('SITE_API_HOST', default='http://localhost:8001/')
 


### PR DESCRIPTION
Django 4 now checks the Origin Header if it is included in POST requests. So we need to add this to make sure that the subdomains are all allowed to make POST requests